### PR TITLE
Added where with OR or AND condition support

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -26,7 +26,15 @@ type (
 		expression   string
 		args         []interface{}
 		placeholders []string
+		condition    FilterCondition
 	}
+)
+
+type FilterCondition int
+
+const (
+	FilterConditionAnd FilterCondition = iota
+	FilterConditionOr
 )
 
 // New creates a new Builder.
@@ -51,6 +59,17 @@ func (b *Builder) Where(query string, args ...interface{}) *Builder {
 	b.filters = append(b.filters, filter{
 		expression: query,
 		args:       args,
+	})
+
+	return b
+}
+
+// WhereCondition set conditions of where in SELECT with specified AND or OR
+func (b *Builder) WhereCondition(query string, condition FilterCondition, args ...interface{}) *Builder {
+	b.filters = append(b.filters, filter{
+		expression: query,
+		args:       args,
+		condition:  condition,
 	})
 
 	return b

--- a/parser_test.go
+++ b/parser_test.go
@@ -69,6 +69,15 @@ func TestBuilder(t *testing.T) {
 			wantQuery: "select * from users where `name` = ? and age in (?, ?, ?) order by `name` asc, age desc limit 10, 5",
 			wantArgs:  []interface{}{"John", 25, 30, 35},
 		},
+		{
+			name: "Valid OR Where",
+			setup: func(b *Builder) {
+				b.WhereCondition("name = ?", FilterConditionOr, "John")
+			},
+			baseQuery: "SELECT * FROM users WHERE age > 18",
+			wantQuery: "select * from users where age > 18 or `name` = ?",
+			wantArgs:  []interface{}{"John"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Added support for were with conditions.

```
b.WhereCondition("name = ?", FilterConditionOr, "John")

baseQuery = "SELECT * FROM users WHERE age > 18",
```

leads to a query like below - 

```
"select * from users where age > 18 or `name` = ?",
```